### PR TITLE
Add functions to collect all comps and mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - MAIN_CMD="pytest"
-    - CONDA_DEPENDENCIES="pytest-cov coveralls coverage codecov pyresample setuptools"
+    - CONDA_DEPENDENCIES="pytest-cov coveralls coverage codecov satpy pyresample setuptools"
     - PIP_DEPENDENCIES=""
     - CONDA_CHANNELS="conda-forge"
     - CONDA_CHANNEL_PRIORITY="strict"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-install_requires = pyresample; setuptools
+install_requires = satpy; pyresample; setuptools
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/sattools/ptc.py
+++ b/src/sattools/ptc.py
@@ -14,6 +14,10 @@ def get_all_areas(packages):
     D = {}
     for pkg in packages:
         fn = pkg_resources.resource_filename(pkg, "etc/areas.yaml")
+        # `load_area` does not currently give a sane error if a file does not
+        # exist, see https://github.com/pytroll/pyresample/issues/250
+        # manually test that file exists and can be read
+        open(fn, "r").close()
         areas = pyresample.area_config.load_area(fn)
         D.update({ar.area_id: ar for ar in areas})
     return D

--- a/src/sattools/ptc.py
+++ b/src/sattools/ptc.py
@@ -1,6 +1,8 @@
 """Utilities related to pytroll configuration
 """
 
+import satpy.composites
+import satpy.config
 import pkg_resources
 import pyresample
 
@@ -15,3 +17,27 @@ def get_all_areas(packages):
         areas = pyresample.area_config.load_area(fn)
         D.update({ar.area_id: ar for ar in areas})
     return D
+
+
+def add_pkg_comps_mods(scn, pkg, sensors=["abi"]):
+    """Add composites and modifiers to sensor dictionary for one package
+
+    Awaiting a solution to the issue at
+    https://github.com/pytroll/satpy/issues/784 for a proper plugin system,
+    this function will take an existing Scene object and makes it aware of
+    composites and modifiers
+    """
+    p = pkg_resources.resource_filename(pkg, "etc/")
+    cpl = satpy.composites.CompositorLoader(p)
+    (comps, mods) = cpl.load_compositors(sensors)
+    satpy.config.recursive_dict_update(scn.dep_tree.composites, comps)
+    satpy.config.recursive_dict_update(scn.dep_tree.mods, mods)
+
+
+def add_all_pkg_comps_mods(scn, pkgs, sensors=["abi"]):
+    """Add composites and modifiers to sensor dictionary for all packages
+
+    See :func:`add_pkg_comps_mods`.
+    """
+    for pkg in pkgs:
+        add_pkg_comps_mods(scn, pkg, sensors)

--- a/src/sattools/ptc.py
+++ b/src/sattools/ptc.py
@@ -34,7 +34,7 @@ def add_pkg_comps_mods(scn, pkg, sensors=["abi"]):
     p = pkg_resources.resource_filename(pkg, "etc/")
     cpl = satpy.composites.CompositorLoader(p)
     (comps, mods) = cpl.load_compositors(sensors)
-    satpy.config.recursive_dict_update(scn.dep_tree.composites, comps)
+    satpy.config.recursive_dict_update(scn.dep_tree.compositors, comps)
     satpy.config.recursive_dict_update(scn.dep_tree.mods, mods)
 
 

--- a/src/sattools/ptc.py
+++ b/src/sattools/ptc.py
@@ -35,7 +35,7 @@ def add_pkg_comps_mods(scn, pkg, sensors=["abi"]):
     cpl = satpy.composites.CompositorLoader(p)
     (comps, mods) = cpl.load_compositors(sensors)
     satpy.config.recursive_dict_update(scn.dep_tree.compositors, comps)
-    satpy.config.recursive_dict_update(scn.dep_tree.mods, mods)
+    satpy.config.recursive_dict_update(scn.dep_tree.modifiers, mods)
 
 
 def add_all_pkg_comps_mods(scn, pkgs, sensors=["abi"]):

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import patch, MagicMock
 
 
@@ -13,14 +14,17 @@ def test_get_areas():
              'no_defs': 'None', 'proj': 'eqc', 'type': 'crs', 'units': 'm',
              'x_0': 0, 'y_0': 0},
             750, 300, (2500000, 4000000, 3000000, 40000000))
-    with patch("pyresample.area_config.load_area", autospec=True) as pal, \
-            patch("pkg_resources.resource_filename", autospec=True) as prf:
+    with patch("pkg_resources.resource_filename", autospec=True) as prf:
         prf.return_value = "/dev/null"
-        pal.return_value = [ad]
-        D = sattools.ptc.get_all_areas(["tofu", "tempeh"])
-        assert prf.call_count == 2
-        assert pal.call_count == 2
-        assert D == {"shrubbery": ad}
+        with patch("pyresample.area_config.load_area", autospec=True) as pal:
+            pal.return_value = [ad]
+            D = sattools.ptc.get_all_areas(["tofu", "tempeh"])
+            assert prf.call_count == 2
+            assert pal.call_count == 2
+            assert D == {"shrubbery": ad}
+        prf.return_value = "/file/not/found"
+        with pytest.raises(FileNotFoundError):
+            sattools.ptc.get_all_areas(["oranges"])
 
 
 def test_add_pkg():

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -14,7 +14,7 @@ def test_get_areas():
              'x_0': 0, 'y_0': 0},
             750, 300, (2500000, 4000000, 3000000, 40000000))
     with patch("pyresample.area_config.load_area", autospec=True) as pal, \
-         patch("pkg_resources.resource_filename", autospec=True) as prf:
+            patch("pkg_resources.resource_filename", autospec=True) as prf:
         prf.return_value = "/dev/null"
         pal.return_value = [ad]
         D = sattools.ptc.get_all_areas(["tofu", "tempeh"])
@@ -27,7 +27,7 @@ def test_add_pkg():
     import sattools.ptc
     scn = MagicMock()
     with patch("satpy.composites.CompositorLoader", autospec=True) as scC, \
-         patch("pkg_resources.resource_filename", autospec=True) as prf:
+            patch("pkg_resources.resource_filename", autospec=True) as prf:
         prf.return_value = "/dev/null"
         scC.return_value.load_compositors.return_value = ({}, {})
         sattools.ptc.add_pkg_comps_mods(scn, "apple", ["tomato"])
@@ -36,5 +36,6 @@ def test_add_pkg():
 def test_add_pkgs():
     import sattools.ptc
     scn = MagicMock()
-    with patch("sattools.ptc.add_all_pkg_comps_mods", autospec=True) as spa:
-        sattools.ptc.add_all_pkg_comps_mods(scn, ["apple", "strawberry"], ["tomato"])
+    with patch("sattools.ptc.add_all_pkg_comps_mods", autospec=True):
+        sattools.ptc.add_all_pkg_comps_mods(
+                scn, ["apple", "strawberry"], ["tomato"])

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -40,6 +40,6 @@ def test_add_pkg():
 def test_add_pkgs():
     import sattools.ptc
     scn = MagicMock()
-    with patch("sattools.ptc.add_all_pkg_comps_mods", autospec=True):
+    with patch("sattools.ptc.add_pkg_comps_mods", autospec=True):
         sattools.ptc.add_all_pkg_comps_mods(
                 scn, ["apple", "strawberry"], ["tomato"])

--- a/tests/test_ptc.py
+++ b/tests/test_ptc.py
@@ -1,23 +1,40 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
-@patch("pyresample.area_config.load_area", autospec=True)
-@patch("pkg_resources.resource_filename", autospec=True)
-def test_get_areas(prf, pac):
+def test_get_areas():
     # need to mock pkg_resources.resource_filename
     # and pyresample.area_config.load_area
     # such that I get a list of areas
     import pyresample.geometry
     import sattools.ptc
-    prf.return_value = "/dev/null"
     ad = pyresample.geometry.AreaDefinition(
             "shrubbery", "it is a good shrubbery", "shrub",
             {'ellps': 'WGS84', 'lat_0': '0', 'lat_ts': '0', 'lon_0': '0',
              'no_defs': 'None', 'proj': 'eqc', 'type': 'crs', 'units': 'm',
              'x_0': 0, 'y_0': 0},
             750, 300, (2500000, 4000000, 3000000, 40000000))
-    pac.return_value = [ad]
-    D = sattools.ptc.get_all_areas(["tofu", "tempeh"])
-    assert prf.call_count == 2
-    assert pac.call_count == 2
-    assert D == {"shrubbery": ad}
+    with patch("pyresample.area_config.load_area", autospec=True) as pal, \
+         patch("pkg_resources.resource_filename", autospec=True) as prf:
+        prf.return_value = "/dev/null"
+        pal.return_value = [ad]
+        D = sattools.ptc.get_all_areas(["tofu", "tempeh"])
+        assert prf.call_count == 2
+        assert pal.call_count == 2
+        assert D == {"shrubbery": ad}
+
+
+def test_add_pkg():
+    import sattools.ptc
+    scn = MagicMock()
+    with patch("satpy.composites.CompositorLoader", autospec=True) as scC, \
+         patch("pkg_resources.resource_filename", autospec=True) as prf:
+        prf.return_value = "/dev/null"
+        scC.return_value.load_compositors.return_value = ({}, {})
+        sattools.ptc.add_pkg_comps_mods(scn, "apple", ["tomato"])
+
+
+def test_add_pkgs():
+    import sattools.ptc
+    scn = MagicMock()
+    with patch("sattools.ptc.add_all_pkg_comps_mods", autospec=True) as spa:
+        sattools.ptc.add_all_pkg_comps_mods(scn, ["apple", "strawberry"], ["tomato"])


### PR DESCRIPTION
Add two functions to collect some or all composites and modifiers and
add them to a scene.  This as a workaround for https://github.com/pytroll/satpy/issues/784