### PR TITLE
Raise TypeError if no areas passed to area-joining

### DIFF
--- a/src/sattools/area.py
+++ b/src/sattools/area.py
@@ -10,6 +10,8 @@ def join_areadefs(*areas):
     """
 
     first = None
+    if len(areas) == 0:
+        raise TypeError("Must pass at least one area, found zero.")
     for area in areas:
         if first is None:
             first = area

--- a/tests/test_area.py
+++ b/tests/test_area.py
@@ -52,3 +52,5 @@ def test_join_areadefs():
         join_areadefs(ar3, ar4)
     with pytest.raises(ValueError):
         join_areadefs(ar3, ar5)
+    with pytest.raises(TypeError):
+        join_areadefs()


### PR DESCRIPTION
Raise a TypeError if the user attempts to merge multiple areas but passes zero.