### PR TITLE
Return fsfile not fileinfo with glm

### DIFF
--- a/src/sattools/glm.py
+++ b/src/sattools/glm.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from typhon.files.fileset import FileSet
+from . import tputil
 
 pattern_s3_glm_lcfa = (
         "noaa-goes16/GLM-L2-LCFA/{year}/{doy}/{hour}/"
@@ -113,7 +114,8 @@ def ensure_glm_for_period(
     else:
         pat = get_pattern_dwd_glm(sector, lat=lat, lon=lon)
     glm = FileSet(path=pat, name="glm")
-    yield from glm.find(start_date, end_date, no_files_error=True)
+    for fileinfo in glm.find(start_date, end_date, no_files_error=True):
+        yield tputil.fileinfo2fspath(fileinfo)
 
 
 def find_glm_coverage(start_date, end_date, sector="C", lat=None, lon=None):

--- a/src/sattools/glm.py
+++ b/src/sattools/glm.py
@@ -84,7 +84,7 @@ def ensure_glm_for_period(
         start_date, end_date, sector="C", lat=None, lon=None):
     """Get gridded GLM for period, unless already existing.
 
-    Yields resulting GLM files.
+    Yields resulting GLM files as FSPath objects.
     """
     logger.debug(
             "Locating GLM gaps between "

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -1,4 +1,6 @@
 """Test functionality related to glm module."""
+
+import os
 import pathlib
 import datetime
 import logging
@@ -111,7 +113,7 @@ def test_ensure_glm(sS, au, sgr, glm_files, lcfa_pattern,
     from sattools.glm import ensure_glm_for_period
     from sattools.glm import get_pattern_dwd_glm
     from fsspec.implementations.local import LocalFileSystem
-    from typhon.files.fileset import FileInfo
+    from satpy.readers import FSFile
     monkeypatch.setenv("NAS_DATA", str(tmp_path / "nas"))
     au.return_value = str(tmp_path / "whole-file-cache")
     sS.return_value = LocalFileSystem()
@@ -138,13 +140,11 @@ def test_ensure_glm(sS, au, sgr, glm_files, lcfa_pattern,
                 datetime.datetime(1900, 1, 1, 0, 6, 0),
                 sector="C")
         fi = next(g)
-        assert isinstance(fi, FileInfo)
-        assert fi.path == str(
+        assert isinstance(fi, FSFile)
+        assert os.fspath(fi) == os.fspath(
                 tmp_path / "nas" / "GLM-processed" / "C" /
                 "1min" / "1900" / "01" / "01" / "00" /
                 "OR_GLM-L2-GLMC-M3_G16_s1900001000000*_e1900001000100*_c*.nc")
-        assert fi.times == [datetime.datetime(1900, 1, 1, 0, 0),
-                            datetime.datetime(1900, 1, 1, 0, 1)]
 
         g = ensure_glm_for_period(
                 datetime.datetime(1900, 1, 1, 0, 0, 0),
@@ -153,7 +153,7 @@ def test_ensure_glm(sS, au, sgr, glm_files, lcfa_pattern,
                 lat=10,
                 lon=20)
         fi = next(g)
-        assert fi.path == str(
+        assert os.fspath(fi) == os.fspath(
                 tmp_path / "nas" / "GLM-processed" / "M1" / "10.0_20.0" /
                 "1min" / "1900" / "01" / "01" / "00" /
                 "OR_GLM-L2-GLMM1-M3_G16_s1900001000000*_e1900001000100*_c*.nc")


### PR DESCRIPTION
When collecting GLM, return FSFile objects, not FileInfo objects.

This is so they can be given to MultiScene and others directly.