### PR TITLE
Wrap path not FileInfo

### DIFF
--- a/src/sattools/abi.py
+++ b/src/sattools/abi.py
@@ -47,7 +47,7 @@ def get_fsfiles(start_date, end_date, sector="F", chans=14):
     files = list(
             fi for fi in abi_fileset.find(start_date, end_date)
             if any(f"C{c:>02d}_" in fi.path for c in chans))
-    return [satpy.readers.FSFile(f, fs_block) for f in files]
+    return [satpy.readers.FSFile(fi.path, fs=fs_block) for fi in files]
 
 
 def split_meso(ms):

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -12,6 +12,7 @@ def test_get_fs_and_files(sS, tmp_path, monkeypatch, sector):
     """Test getting FSFile objects."""
     from sattools.abi import get_fsfiles
     from fsspec.implementations.local import LocalFileSystem
+    from fsspec.implementations.cached import CachingFileSystem
     from satpy.readers import FSFile
 
     sS.side_effect = LocalFileSystem
@@ -36,6 +37,8 @@ def test_get_fs_and_files(sS, tmp_path, monkeypatch, sector):
                     f"M6C{c:>02d}_G16_s19000010005000_e19000010010000_"
                     "c20303212359590.nc")
                 for c in {2, 3}]
+    assert isinstance(fsfs[0]._file, str)
+    assert isinstance(fsfs[0]._fs, CachingFileSystem)
 
     assert get_fsfiles(
             datetime.datetime(1900, 1, 1, 0),

--- a/tests/test_tputil.py
+++ b/tests/test_tputil.py
@@ -12,3 +12,4 @@ def test_fileinfo2fspath():
     fi = FileInfo("/tmp/tofu", fs=lfs)
     fsf = FSFile("/tmp/tofu", fs=lfs)
     assert fileinfo2fspath(fi) == fsf
+    assert isinstance(fsf._file, str)


### PR DESCRIPTION
When passing ABI FSFiles, make the FSFile wrap a path, not a typhon
FileInfo.