### PR TITLE
Collapse glm abi multiscene

### DIFF
--- a/src/sattools/scutil.py
+++ b/src/sattools/scutil.py
@@ -166,3 +166,28 @@ def get_abi_glm_multiscenes(start_date, end_date, chans, sector,
                 "one-to-one match between GLM-files and ABI-files, and GLM "
                 "processing remains hardcoded for 1-minute. "
                 "See https://github.com/gerritholl/sattools/issues/34")
+
+
+def collapse_abi_glm_multiscene(ms):
+    """Collapse an inhomogeneous ABI-GLM multiscene.
+
+    When an ABI-GLM multiscene has been collected, such as with
+    get_abi_glm_multiscenes, we may have a patterns in which every step has GLM
+    data but only some steps have ABI data.  This function integrates
+    subsequent GLM data and produces a multiscene in which each scene has
+    exactly one ABI and one GLM.
+    """
+
+    # We want to integrate GLM until the next ABI.  Or average?
+    # Maybe average is safer so we don't get artificially high flash
+    # densities should an ABI be missing on occasion.
+
+    for sc in ms.scenes:
+        for did in sc.keys():
+            if (sens:=sc[did].attrs["sensor"]) == "glm":
+                ...
+            elif sens == "abi":
+                ...
+            else:
+                ...
+    raise NotImplementedError()

--- a/src/sattools/scutil.py
+++ b/src/sattools/scutil.py
@@ -176,12 +176,18 @@ def collapse_abi_glm_multiscene(ms):
     get_abi_glm_multiscenes, we may have a patterns in which every step has GLM
     data but only some steps have ABI data.  This function integrates
     subsequent GLM data and produces a multiscene in which each scene has
-    exactly one ABI and one GLM.
-    """
+    exactly one ABI and one GLM, by averaging GLM flash extent densities up to
+    the next available ABI.
 
-    # We want to integrate GLM until the next ABI.  Or average?
-    # Maybe average is safer so we don't get artificially high flash
-    # densities should an ABI be missing on occasion.
+    Args:
+        ms (satpy.MultiScene)
+            Multiscene for which averaging will be applied, where all scenes
+            have GLM but not all scenes have ABI.
+
+    Returns:
+        satpy.MultiScene
+            New (shorter) MultiScene where each scene has both GLM and ABI.
+    """
 
     scenes = []
     glm = {}
@@ -189,7 +195,7 @@ def collapse_abi_glm_multiscene(ms):
     for old in ms.scenes:
         for did in sorted(old.keys()):
             if (sens:=old[did].attrs["sensor"]) == "glm":
-                if did.name == "flash_extent_density":
+                if did["name"] == "flash_extent_density":
                     if not did in glm:
                         glm[did] = []
                     glm[did].append(old[did])

--- a/src/sattools/scutil.py
+++ b/src/sattools/scutil.py
@@ -188,15 +188,14 @@ def collapse_abi_glm_multiscene(ms):
         satpy.MultiScene
             New (shorter) MultiScene where each scene has both GLM and ABI.
     """
-
     scenes = []
     glm = {}
     abi_cont = {}
     for old in ms.scenes:
         for did in sorted(old.keys()):
-            if (sens:=old[did].attrs["sensor"]) == "glm":
+            if (sens := old[did].attrs["sensor"]) == "glm":
                 if did["name"] == "flash_extent_density":
-                    if not did in glm:
+                    if did not in glm:
                         glm[did] = []
                     glm[did].append(old[did])
                 else:
@@ -206,7 +205,7 @@ def collapse_abi_glm_multiscene(ms):
                 abi_cont[did] = old[did]
             else:
                 raise ValueError("I can only handle GLM and ABI, but I got "
-                        f"{sens!s}")
+                                 f"{sens!s}")
         # gone through all in the scene now...
         # if I had new ABI, then make new scene collecting GLM...
         if abi_cont:

--- a/tests/test_scutil.py
+++ b/tests/test_scutil.py
@@ -166,7 +166,7 @@ def test_collapse_multiscene():
     cont_full = cont_part.copy()
     cont_full["strawberry"] = numpy.arange(6*6).reshape(6, 6)
     in_ = satpy.MultiScene(
-        [satpy.tests.utils.make_fake_scene(cont_full if i%3 else cont_part)
+        [satpy.tests.utils.make_fake_scene(cont_full if i%3==0 else cont_part)
             for i in range(6)])
     for sc in in_.scenes:
         sc["flash_extent_density"].attrs["sensor"] = "glm"

--- a/tests/test_scutil.py
+++ b/tests/test_scutil.py
@@ -2,6 +2,8 @@
 import datetime
 import unittest.mock
 
+import numpy
+
 import satpy
 import pytest
 
@@ -156,3 +158,25 @@ def test_get_multiscenes(sag, sge, fake_multiscene4, tmp_path):
                 chans=[8, 10],
                 sector="M1",
                 limit=0)) == []
+
+
+def test_collapse_multiscene():
+    from sattools.scutil import collapse_abi_glm_multiscene
+    cont_part = {"raspberry": numpy.arange(6*6).reshape(6, 6)}
+    cont_full = cont_part.copy()
+    cont_full["strawberry"] = numpy.arange(6*6).reshape(6, 6)
+    in_ = satpy.MultiScene(
+        [satpy.tests.utils.make_fake_scene(cont_full if i%3 else cont_part)
+            for i in range(6)])
+    ref = satpy.MultiScene(
+            [satpy.tests.utils.make_fake_scene(
+                {"raspberry": cont_part["raspberry"],
+                 "strawberry": 3*cont_full["strawberry"]})
+                for i in range(2)])
+    out = collapse_abi_glm_multiscene(in_)
+    # cannot directly compare multiscene or scene, see
+    # https://github.com/pytroll/satpy/issues/1583
+    assert len(out.scenes) == len(ref.scenes)
+    for (outscene, refscene) in zip(out.scenes, ref.scenes):
+        assert (outscene.to_xarray_dataset() ==
+                refscene.to_xarray_dataset()).all()

--- a/tests/test_scutil.py
+++ b/tests/test_scutil.py
@@ -168,6 +168,10 @@ def test_collapse_multiscene():
     in_ = satpy.MultiScene(
         [satpy.tests.utils.make_fake_scene(cont_full if i%3 else cont_part)
             for i in range(6)])
+    for sc in in_.scenes:
+        sc["raspberry"].attrs["sensor"] = "glm"
+        if "strawberry" in sc:
+            sc["strawberry"].attrs["sensor"] = "abi"
     ref = satpy.MultiScene(
             [satpy.tests.utils.make_fake_scene(
                 {"raspberry": cont_part["raspberry"],

--- a/tests/test_scutil.py
+++ b/tests/test_scutil.py
@@ -162,19 +162,19 @@ def test_get_multiscenes(sag, sge, fake_multiscene4, tmp_path):
 
 def test_collapse_multiscene():
     from sattools.scutil import collapse_abi_glm_multiscene
-    cont_part = {"raspberry": numpy.arange(6*6).reshape(6, 6)}
+    cont_part = {"flash_extent_density": numpy.arange(6*6).reshape(6, 6)}
     cont_full = cont_part.copy()
     cont_full["strawberry"] = numpy.arange(6*6).reshape(6, 6)
     in_ = satpy.MultiScene(
         [satpy.tests.utils.make_fake_scene(cont_full if i%3 else cont_part)
             for i in range(6)])
     for sc in in_.scenes:
-        sc["raspberry"].attrs["sensor"] = "glm"
+        sc["flash_extent_density"].attrs["sensor"] = "glm"
         if "strawberry" in sc:
             sc["strawberry"].attrs["sensor"] = "abi"
     ref = satpy.MultiScene(
             [satpy.tests.utils.make_fake_scene(
-                {"raspberry": cont_part["raspberry"],
+                {"flash_extent_density": cont_part["flash_extent_density"],
                  "strawberry": 3*cont_full["strawberry"]})
                 for i in range(2)])
     out = collapse_abi_glm_multiscene(in_)

--- a/tests/test_scutil.py
+++ b/tests/test_scutil.py
@@ -161,12 +161,14 @@ def test_get_multiscenes(sag, sge, fake_multiscene4, tmp_path):
 
 
 def test_collapse_multiscene():
+    """Test collapsing a multiscene."""
     from sattools.scutil import collapse_abi_glm_multiscene
     cont_part = {"flash_extent_density": numpy.arange(6*6).reshape(6, 6)}
     cont_full = cont_part.copy()
     cont_full["strawberry"] = numpy.arange(6*6).reshape(6, 6)
     in_ = satpy.MultiScene(
-        [satpy.tests.utils.make_fake_scene(cont_full if i%3==0 else cont_part)
+        [satpy.tests.utils.make_fake_scene(
+            cont_full if i % 3 == 0 else cont_part)
             for i in range(6)])
     for sc in in_.scenes:
         sc["flash_extent_density"].attrs["sensor"] = "glm"


### PR DESCRIPTION
Collapse GLM ABI Multiscene.  When a Multiscene has GLM in every scene but ABI only in some scenes, average the GLM flash extent density and produce a collapsed MultiScene with GLM and ABI in every scene.